### PR TITLE
Fix inconsistent font sizes in code blocks on iOS Safari

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.playwright-mcp/

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -315,6 +315,7 @@ a {
 }
 
 pre {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
     font-size: 16px;
     color: #cdd6f4;
     background-color: #1e1e2e;
@@ -325,6 +326,14 @@ pre {
     white-space: pre-wrap;
     word-wrap: break-word;
     overflow-x: auto;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+}
+
+pre * {
+    font-size: inherit !important;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
 }
 
 /* Mobile styles */

--- a/static/css/chroma.css
+++ b/static/css/chroma.css
@@ -1,6 +1,6 @@
 /* Catppuccin Mocha theme for Chroma syntax highlighting */
 /* Background */ .bg { color: #cdd6f4; background-color: #1e1e2e; }
-/* PreWrapper */ .chroma { color: #cdd6f4; background-color: #1e1e2e; }
+/* PreWrapper */ .chroma { color: #cdd6f4; background-color: #1e1e2e; font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace; }
 /* Error */ .chroma .err { color: #f38ba8 }
 /* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
@@ -8,7 +8,7 @@
 /* LineHighlight */ .chroma .hl { background-color: #45475a }
 /* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f849c }
 /* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f849c }
-/* Line */ .chroma .line { display: flex; }
+/* Line */ .chroma .line { display: block; }
 /* Keyword */ .chroma .k { color: #cba6f7 }
 /* KeywordConstant */ .chroma .kc { color: #fab387 }
 /* KeywordDeclaration */ .chroma .kd { color: #f38ba8 }


### PR DESCRIPTION
## Summary
- iOS Safariのtext-size-adjust機能によりコードブロック内のフォントサイズが不揃いになる問題を修正
- `pre`と`.chroma`要素に等幅フォントファミリーを明示的に指定
- `-webkit-text-size-adjust: 100%`でiOSの自動調整を無効化

## Test plan
- [ ] iPhoneのSafari（プライベートモード）でコードブロックのフォントサイズが揃っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)